### PR TITLE
Fix types definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "types": "types/index.d.ts",
   "type": "module",
   "exports": {
+    "types": "./types/index.d.ts",
     "import": "./dist/index.mjs",
     "require": "./dist/index.cjs"
   },


### PR DESCRIPTION
Currently vscode will report the error:

```
Could not find a declaration file for module 'rollup-plugin-dev'. '/.../node_modules/rollup-plugin-dev/dist/index.mjs' implicitly has an 'any' type.
  There are types at '/.../node_modules/rollup-plugin-dev/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'rollup-plugin-dev' library may need to update its package.json or typings. ts(7016)
```
